### PR TITLE
Removing CUDA dependencies for Darknet yolov3

### DIFF
--- a/ros/src/computing/perception/detection/vision_detector/packages/vision_darknet_detect/CMakeLists.txt
+++ b/ros/src/computing/perception/detection/vision_detector/packages/vision_darknet_detect/CMakeLists.txt
@@ -158,5 +158,49 @@ IF (CUDA_FOUND)
             RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
             )
 ELSE()
-    message("darknet won't be built, CUDA was not found.")
+    message("CUDA was not found, attempting to build CPU-darknet.")
+    #removing CUDA dependencies so Darknet yolo-v3 can be run. Darknet must be built natively in order to work (simalar to Caffe installation).
+    	
+        include_directories(
+		${catkin_INCLUDE_DIRS}
+	)
+	
+        #CPU_DARKNET_PATH must be the location of the "darknet" directory.
+	set(CPU_DARKNET_PATH "$ENV{HOME}/darknet")
+
+	add_executable(vision_darknet_detect
+		src/vision_darknet_detect_node.cpp
+		src/vision_darknet_detect.cpp
+		src/vision_darknet_detect.h
+	)
+
+	include_directories(vision_darknet_detect PRIVATE
+		${OpenCV_INCLUDE_DIRS}
+		${catkin_INCLUDE_DIRS}
+		${Boost_INCLUDE_DIRS}
+		${CPU_DARKNET_PATH}
+		${CPU_DARKNET_PATH}/include
+		${CPU_DARKNET_PATH}/src
+		${CPU_DARKNET_PATH}/obj
+		src
+	)
+
+	target_link_libraries(vision_darknet_detect
+		${CPU_DARKNET_PATH}/libdarknet.so
+		${catkin_LIBRARIES}
+		${OpenCV_LIBRARIES}
+		${PCL_LIBRARIES}
+		${Qt5Core_LIBRARIES}
+	)
+
+	add_dependencies(vision_darknet_detect
+		${catkin_EXPORTED_TARGETS}
+	)
+
+	install(TARGETS vision_darknet_detect
+		ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+		LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+		RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+	)
+    
 ENDIF ()


### PR DESCRIPTION
## Status
**PRODUCTION / DEVELOPMENT**

## Description
Fix autowarefoundation/autoware_ai#455

If the host machine does not have CUDA, this will attempt to build the vision_darknet_detect package based on a pre-built darknet directory (which doesn't require CUDA as there are no CUDA dependencies for yolov3).

## Steps to Test or Reproduce
If the system has CUDA there should be no issue. If CUDA is not present then darknet must be build in the home directory:
```
$ cd && git clone https://github.com/pjreddie/darknet.git
$ cd ~/darknet && make
```
After darknet has been built, the Autoware node for vision_darknet_detect can be recompiled, and should have no issues:
In order to just compile vision_darknet_detect the following command can be executed:
```
$ catkin_make --DCATKIN_WHITELIST_PACKAGES="vision_darknet_detect"
```
Now the following should run with no errors on a system that does not have CUDA
```
roslaunch vision_darknet_detect vision_darknet_detect
```
